### PR TITLE
Changed token expire logic.

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -131,7 +131,7 @@ class JWT
         }
 
         // Check if this token has expired.
-        if (isset($payload->exp) && ($timestamp - static::$leeway) >= $payload->exp) {
+        if (isset($payload->exp) && ($timestamp - $payload->iat) >= $payload->exp) {
             throw new ExpiredException('Expired token');
         }
 


### PR DESCRIPTION
```$timestamp``` is always current time. Can't supply token creation time to ```$leeway```. So token was always identified as expired.